### PR TITLE
Bug fix: sidebar should no longer disappear after making it smaller

### DIFF
--- a/cloud-haven-react-app/src/components/Sidebar/Sidebar.css
+++ b/cloud-haven-react-app/src/components/Sidebar/Sidebar.css
@@ -3,6 +3,7 @@
     padding-top: 20px;
     overflow-x: hidden;
     transition: 0.5s;
+    flex-shrink: 0;
 }
 
 .sidebar-closed {
@@ -39,7 +40,7 @@
     display: block;
     display: flex;
     padding: 0;
-    margin:0;
+    margin: 0;
     margin-bottom: 50px;
     height: 60px;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23527660/114821654-bcd8ee80-9d75-11eb-8aca-a54bbc425926.png)

The property that was causing the sidebar to minimize to a width of 0 when the browser got smaller was flex-shrink. Flex-shrink is implicitly enabled and this change disables flex-shrink.
