### PR TITLE
Fixed the frontend issue of a small screen size causing two scroll bars to appear

### DIFF
--- a/cloud-haven-react-app/src/App.css
+++ b/cloud-haven-react-app/src/App.css
@@ -33,7 +33,7 @@
 
 #PageFrame {
    height: 100vh;
-   width: 100%;
+   width: 100vw;
    border-left: 20px var(--main-bg-color);
    border-left-style: solid;
    background-color: var(--main-bg-color);

--- a/cloud-haven-react-app/src/components/Home/Home.css
+++ b/cloud-haven-react-app/src/components/Home/Home.css
@@ -1,6 +1,5 @@
 .Home {
-    margin: 0;
     padding: 0;
     max-width: 100%;
-    height: 100%
+    height: 100%;
 }

--- a/cloud-haven-react-app/src/components/TopBar/TopBar.css
+++ b/cloud-haven-react-app/src/components/TopBar/TopBar.css
@@ -37,3 +37,9 @@
 a:hover {
    text-decoration: none;
 }
+
+@media only screen and (max-width: 600px) {
+   #CloudHavenHeaderText {
+      display: none
+   }
+}

--- a/cloud-haven-react-app/src/components/TopBar/TopBar.js
+++ b/cloud-haven-react-app/src/components/TopBar/TopBar.js
@@ -7,8 +7,8 @@ function TopBar() {
       <div id="TopBar">
          <a href="/">
             <div id="TopBarHeader">
-            <img id="CloudHavenLogo" alt="Cloud Haven" src={require("../../images/cloudhavensiteicon.png")}/>
-            <span id="CloudHavenHeaderText">CloudHaven</span>
+               <img id="CloudHavenLogo" alt="Cloud Haven" src={require("../../images/cloudhavensiteicon.png")}/>
+               <span id="CloudHavenHeaderText">CloudHaven</span>  
             </div>
          </a>
          <div id="ProfileDropdown" className="pull-right">


### PR DESCRIPTION
Using a media breakpoint in the CSS file for the top bar, once the screen size reaches 600px wide or less, the text within the CloudHaven logo will be removed and just the logo design and the dropdown button will remain on the top bar.
Before:
![Screenshot 2021-04-20 124534](https://user-images.githubusercontent.com/37995716/115471832-7cea8f00-a1ed-11eb-8856-fbaa8cc5fa7d.png)
After the fix:
![Screenshot 2021-04-20 152830](https://user-images.githubusercontent.com/37995716/115471841-7f4ce900-a1ed-11eb-9c3c-017acd33b895.png)
